### PR TITLE
Handle SSH connection timeouts as expected with :on_error

### DIFF
--- a/lib/net/ssh/multi/server.rb
+++ b/lib/net/ssh/multi/server.rb
@@ -187,6 +187,8 @@ module Net; module SSH; module Multi
 
         session[:server] = self
         session
+      rescue ::Timeout::Error => error
+        raise Net::SSH::ConnectionTimeout.new("#{error.message} for #{host}")
       rescue Net::SSH::AuthenticationFailed => error
         raise Net::SSH::AuthenticationFailed.new("#{error.message}@#{host}")
       end


### PR DESCRIPTION
I ran into a problem where :on_error was not handling cases where servers were completely unaccessible (i.e., powered off). Typically, that's not a problem, but it happens semi-routinely where I'm using this. Unfortunately, :on_error didn't seem to affect this. The Timeout::Error exception always hit and there wasn't a very graceful way to rescue it. After doing some looking, it appears as though that was because Net::SSH::AuthenticationFailed was the only exception being rescued that would trigger an :on_error. This patch adds the ::Timeout::Error exception as well. Note that it's dependent on a related patch to net-ssh that adds a new Net::SSH::ConnectionTimeout exception class. Now, a connection timeout will trigger :on_error providing output like this:

error connecting to foo@bar:8000: Net::SSH::ConnectionTimeout (execution expired for bar)

Let me know what you think. There is probably a better way, but this seemed to solve the problem I was running into.
