### PR TITLE
Fix two problems with :concurrent_connections option

### DIFF
--- a/lib/net/ssh/multi/server.rb
+++ b/lib/net/ssh/multi/server.rb
@@ -140,8 +140,9 @@ module Net; module SSH; module Multi
 
     # Returns +true+ if the session has been opened, and the session is currently
     # busy (as defined by Net::SSH::Connection::Session#busy?).
+    # Also returns false if the server has failed to connect.
     def busy?(include_invisible=false)
-      session && session.busy?(include_invisible)
+      !failed? && session && session.busy?(include_invisible)
     end
 
     # Closes this server's session. If the session has not yet been opened,


### PR DESCRIPTION
There are two issues right now in net-ssh-multi with :concurrent_connections option:

1-) There is a race condition while fetching the next_session when :concurrent_connections are set. @open_connections is being incremented by the connection thread and sometimes realize_pending_connections!() method can create more than required connection threads before the @open_connections is set by the previously created threads.

2-) When :concurrent_connections is set, server classes are setup with PendingConnection objects that always return true to busy? calls. If a connection fails when  :concurrent_connections is set, server ends up returning true to all busy? calls since the session object is not replaced. Due to this, main event loop (process() function) never gets terminated. 

1 causes chef not to honour the -C option in knife. 2 causes knife ssh to hang if -C option is specified.

This PR contains fixes these issues both. 