### PR TITLE
Fixed host parsing to work with ipv6 addresses

### DIFF
--- a/lib/net/ssh/multi/server.rb
+++ b/lib/net/ssh/multi/server.rb
@@ -44,7 +44,7 @@ module Net; module SSH; module Multi
       @master = master
       @options = options.dup
 
-      @user, @host, port = host.match(/^(?:([^;,:=]+)@|)(.*?)(?::(\d+)|)$/)[1,3]
+      @user, @host, port = host.match(/^(?:([^;,:=]+)@|)\[?(.*?)\]?(?::(\d+)|)$/)[1,3]
 
       user_opt, port_opt = @options.delete(:user), @options.delete(:port)
 

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -14,6 +14,10 @@ class ServerTest < Minitest::Test
     assert_equal "hello", server('host', :properties => { :foo => "hello" })[:foo]
   end
 
+  def test_ipv6_works_with_given_port_using_bracket_notation
+    assert_equal 9022, server('[2001:DB8::1234]:9022').port
+  end
+
   def test_port_should_return_22_by_default
     assert_equal 22, server('host').port
   end


### PR DESCRIPTION
can now put [ ] around the ip address, without this ipv6 addresses that
are like 2605:fd00:4:1000:f816:3eff:fe33:4679 would be have '4679' be
interpreted as a port number.
