### PR TITLE
add require 'timeout'

### DIFF
--- a/lib/net/ssh/multi/server.rb
+++ b/lib/net/ssh/multi/server.rb
@@ -1,4 +1,5 @@
 require 'net/ssh'
+require 'timeout'
 
 module Net; module SSH; module Multi
   # Encapsulates the connection information for a single remote server, as well


### PR DESCRIPTION
Fixes, test error with net-ssh 3.0.1 

 session that cannot authenticate adds host to exception message
      NameError: uninitialized constant Timeout