### PR TITLE
Use max_select_wait_time to limit IO#select sleep

### DIFF
--- a/lib/net/ssh/multi/server.rb
+++ b/lib/net/ssh/multi/server.rb
@@ -229,5 +229,9 @@ module Net; module SSH; module Multi
         listeners = session.listeners.keys
         session.postprocess(listeners & readers, listeners & writers)
       end
+
+      def max_select_wait_time
+        session.max_select_wait_time if session
+      end
   end
 end; end; end

--- a/lib/net/ssh/multi/session.rb
+++ b/lib/net/ssh/multi/session.rb
@@ -442,12 +442,11 @@ module Net; module SSH; module Multi
     end
 
     def io_select_wait(wait)
-      [wait, keepalive_interval].compact.min
+      [wait, max_select_wait_time].compact.min
     end
 
-    def keepalive_interval
-      servers = server_list.select { |s| s.options[:keepalive] }
-      servers.map { |s| s.options[:keepalive_interval] }.compact.min
+    def max_select_wait_time
+      server_list.map(&:max_select_wait_time).compact.min
     end
 
     # Runs the preprocess stage on all servers. Returns false if the block

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -211,6 +211,19 @@ class ServerTest < Minitest::Test
     assert_equal :result, srv.postprocess([1,11,3], [18,14,7,12])
   end
 
+  def test_max_select_wait_time_should_call_session_max_select_wait_time_when_session_is_open
+    srv = server('host')
+    session = expect_connection_to(srv)
+    session.expects(:max_select_wait_time).returns(:result)
+    srv.session(true)
+    assert_equal :result, srv.max_select_wait_time
+  end
+
+  def test_max_select_wait_time_should_return_nil_when_session_is_not_open
+    srv = server('host')
+    assert_nil srv.max_select_wait_time
+  end
+
   private
 
     class MockIO


### PR DESCRIPTION
Followup to #8.

If keepalive is enabled but no interval is provided, we should use [the same default interval as Net::SSH](https://github.com/net-ssh/net-ssh/blob/v3.1.1/lib/net/ssh/connection/keepalive.rb#L23). Currently the keepalive setting is ignored unless an interval is provided.
