### PR TITLE
Fix warnings

### DIFF
--- a/lib/net/ssh/multi/pending_connection.rb
+++ b/lib/net/ssh/multi/pending_connection.rb
@@ -43,7 +43,7 @@ module Net; module SSH; module Multi
 
       def replay_on(session)
         forward = session.forward
-        @recordings.each {|args| forward.send *args}
+        @recordings.each { |args| forward.send(*args) }
       end
     end
 

--- a/lib/net/ssh/multi/server.rb
+++ b/lib/net/ssh/multi/server.rb
@@ -56,6 +56,7 @@ module Net; module SSH; module Multi
 
       @gateway = @options.delete(:via)
       @failed = false
+      @session = @ready_session = nil
     end
 
     # Returns the value of the server property with the given +key+. Server

--- a/lib/net/ssh/multi/session_actions.rb
+++ b/lib/net/ssh/multi/session_actions.rb
@@ -118,8 +118,8 @@ module Net; module SSH; module Multi
     #   end
     def exec(command, &block)
       open_channel do |channel|
-        channel.exec(command) do |ch, success|
-          raise "could not execute command: #{command.inspect} (#{ch[:host]})" unless success
+        channel.exec(command) do |c, success|
+          raise "could not execute command: #{command.inspect} (#{c[:host]})" unless success
 
           channel.on_data do |ch, data|
             if block

--- a/test/channel_test.rb
+++ b/test/channel_test.rb
@@ -3,7 +3,7 @@ require 'net/ssh/multi/channel'
 
 class ChannelTest < Minitest::Test
   def test_each_should_iterate_over_each_component_channel
-    channels = [c1 = mock('channel'), c2 = mock('channel'), c3 = mock('channel')]
+    channels = [mock('channel'), mock('channel'), mock('channel')]
     channel = Net::SSH::Multi::Channel.new(mock('session'), channels)
     result = []
     channel.each { |c| result << c }

--- a/test/session_actions_test.rb
+++ b/test/session_actions_test.rb
@@ -94,7 +94,7 @@ class SessionActionsTest < Minitest::Test
     c.expects(:on_extended_data).yields(c, 1, "stderr")
     c.expects(:on_request)
     results = {}
-    @session.exec("something") do |c, stream, data|
+    @session.exec("something") do |_, stream, data|
       results[stream] = data
     end
     assert_equal({:stdout => "stdout", :stderr => "stderr"}, results)


### PR DESCRIPTION
```
test/channel_test.rb:6: warning: assigned but unused variable - c1
test/channel_test.rb:6: warning: assigned but unused variable - c2
test/channel_test.rb:6: warning: assigned but unused variable - c3
lib/net/ssh/multi/pending_connection.rb:46: warning: `*' interpreted as argument prefix
lib/net/ssh/multi/session_actions.rb:124: warning: shadowing outer local variable - ch
lib/net/ssh/multi/session_actions.rb:134: warning: shadowing outer local variable - ch
lib/net/ssh/multi/session_actions.rb:144: warning: shadowing outer local variable - ch
test/session_actions_test.rb:97: warning: shadowing outer local variable - c
lib/net/ssh/multi/server.rb:138: warning: instance variable @session not initialized
```